### PR TITLE
광합성 기능(photosynthesis) 구현

### DIFF
--- a/libs/photosynthesis.h
+++ b/libs/photosynthesis.h
@@ -2,14 +2,18 @@
 #define PHOTOSYNTHESIS_H
 
 #include "common.h"
+#include <stdlib.h>
+#include <softPwm.h>
+#include <lirc/lirc_client.h> // 빌드 시 `-llirc_client` 필요
 
 #define IR_RECEIVER_GPIO 23
 #define IR_SEND_GPIO 24
 #define LED_PIN 25
+#define MAX_BRIGHTNESS 100
 
 /*
 광합성 기능(LED를 통한 광합성 기능)
-by 정영한
+by 이지현
 */
 void *control_light(void *arg);
 

--- a/modules/photosynthesis.c
+++ b/modules/photosynthesis.c
@@ -2,8 +2,54 @@
 
 /*
 광합성 기능(LED를 통한 광합성 기능)
+    리모컨을 통해 사용자로부터 밝기 값 받아오기
+    LED를 사용해 식물에 빛 공급
+    밝기 조절 : 0 ~ 100
 */
+
 void* control_light(void* arg){
-    // 리모컨을 통해 사용자로부터 밝기 값 받아오기
-    // LED를 사용해 식물에 빛 공급
+
+    struct lirc_config *config; //IR 설정 값 저장소
+    int brightness = 40; // LED 초기값
+
+    softPwmCreate(LED_PIN, brightness, MAX_BRIGHTNESS); // softPWM 설정
+    
+    if(lirc_init("lirc", 1) == -1){ // lirc 초기화
+        return 1;
+    }
+
+    // lirc 설정 파일을 읽음
+    if(lirc_readconfig(NULL, &config, NULL)== 0){
+        char *code;
+        char *c;
+
+        while(lirc_nextcode(&code) == 0) {
+            //IR코드 수신되면
+            if(code!=NULL){
+                if((lirc_code2char(config, code, &c)) == 0 && c!= NULL)
+                {
+                    if(strcmp(c, "KEY_UP") == 0) { //수신값이 "KEY_UP"일 때 밝기 증가
+                        brightness += 20;
+                        if(brightness > 100) {
+                            brightness = MAX_BRIGHTNESS;
+                        }
+                    }
+                    else if(strcmp(c, "KEY_DOWN") == 0) { //수신값이 "KEY_DOWN"일 때 밝기 감소
+                        brightness -= 20;
+                        if(brightness < 0) {
+                            brightness = 0;
+                        }
+                    }
+                    softPwmWrite(LED_PIN, brightness); //LED 값 설정
+                    printf("[LED] Current Brightness: %d\n", brightness);
+                }
+            }
+        }
+        free(code);
+        lirc_freeconfig(config);
+    }
+    
+    //연결 설정 해제
+    softPwmStop(LED_PIN);
+    lirc_deinit();
 }


### PR DESCRIPTION
- 리모컨으로 LED 밝기 조절 기능 구현
- 기본 설정 
  - /boot/config.txt
  `dtoverlay=gpio-ir, gpio_pin=23`
  - /etc/lirc/lircd_options.config
  `driver = default \\n
device = /dev/lirc0`
  - `sudo apt-get ir-keytable lirc liblircclient-dev`
  - `irrecord`로 리모컨 등록 필요 (이때 raw_code로 작성)
    raw_code는 `sudo mode2 -m -d /dev/lirc0`
(참고 : https://asimuzzaman.com/posts/how-to-use-raspberry-pi-as-infrared-ir-remote)
- 빌드 시 `-llirc_client` 필요